### PR TITLE
disable sleep by stay awake

### DIFF
--- a/app/src/main/java/me/neversleep/plusplus/HookImpl.java
+++ b/app/src/main/java/me/neversleep/plusplus/HookImpl.java
@@ -52,10 +52,9 @@ public class HookImpl {
                //for #4
                if (xSharedPreferences.getBoolean("disable_sleep", false)) {
                     XUtils.xLog("neversleep", "disable sleep:  true");
-                    //ref:https://www.cnblogs.com/crushgirl/p/15630106.html
-                    //ref:https://cs.android.com/android/platform/superproject/+/android-14.0.0_r1:frameworks/base/services/core/java/com/android/server/power/PowerManagerService.java;drc=b3691fab2356133dfc7e11c213732ffef9a85315;l=2876
-                    //ref:https://cs.android.com/android/platform/superproject/+/android-14.0.0_r1:frameworks/base/services/core/java/com/android/server/power/PowerManagerService.java;drc=b3691fab2356133dfc7e11c213732ffef9a85315;l=3108
-                    XposedBridge.hookAllMethods(XposedHelpers.findClass("com.android.server.power.PowerManagerService", classLoader), "handleUserActivityTimeout", XC_MethodReplacement.returnConstant(null));
+					//let device believe it is being kept awake by a wake lock
+                    //ref:https://cs.android.com/android/platform/superproject/+/android-14.0.0_r1:frameworks/base/services/core/java/com/android/server/power/PowerManagerService.java;drc=b3691fab2356133dfc7e11c213732ffef9a85315;l=3271
+                    XposedBridge.hookAllMethods(XposedHelpers.findClass("com.android.server.power.PowerManagerService", classLoader), "isBeingKeptAwakeLocked", XC_MethodReplacement.returnConstant(true));
                     XUtils.xLog("neversleep", "main: Hook disable_sleep success");
                }
           } catch (Throwable th) {


### PR DESCRIPTION
https://cs.android.com/android/platform/superproject/+/android-14.0.0_r1:frameworks/base/services/core/java/com/android/server/power/PowerManagerService.java;l=3271

    /**
     * Returns true if the provided {@link PowerGroup} is being kept awake by a wake lock, user
     * activity or the stay on while powered setting.  We also keep the phone awake when the
     * proximity sensor returns a positive result so that the device does not lock while in a phone
     * call. This function only controls whether the device will go to sleep or dream which is
     * independent of whether it will be allowed to suspend.
   **/

根据这行描述，可以通过这种方案保持屏幕唤醒
   